### PR TITLE
bug: fix crash on new note

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -17,11 +17,14 @@ class NotesController < ApplicationController
 
   def create
     @note = current_user.notes.build(note_params)
+    @note.owner = current_user
+
     if @note.save
+      @note.users << current_user unless @note.users.include?(current_user) # Add to collaborators
       redirect_to notes_path, notice: "Note created successfully."
     else
       flash.now[:alert] = "Note creation failed."
-      render :new, status: :unprocessable_entity
+      render :index, status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
#136

The main modification ensures that the note's owner is set to the current user upon creation and adds the current user to the note's collaborators if not already included. 

Additionally, it updates the render action to use `:index` instead of `:new` in case of an unprocessable entity status.
